### PR TITLE
Backticked function are handled by the parser now (not by the lexer).

### DIFF
--- a/src/org/elmlang/intellijplugin/Elm.bnf
+++ b/src/org/elmlang/intellijplugin/Elm.bnf
@@ -143,13 +143,18 @@ operator_declaration_left ::=
 port_declaration_left ::=
     PORT lower_case_id
 
-expression ::= list_of_operands (some_operator list_of_operands)* { methods = [getReferencesList] }
+expression ::= list_of_operands (any_operator list_of_operands)* { methods = [getReferencesList] }
 
 list_of_operands ::= operand+ { methods = [getReferencesList] }
 
-private some_operator ::=
+private any_operator ::=
+    real_operator
+    | backticked_function
+private real_operator ::=
     OPERATOR
     | LIST_CONSTRUCTOR
+backticked_function ::=
+    BACKTICK referenced_value BACKTICK
 
 private operand ::=
     literal
@@ -185,7 +190,7 @@ private referenced_value ::=
     | mixed_case_path
 
 operator_as_function ::=
-    LEFT_PARENTHESIS some_operator RIGHT_PARENTHESIS
+    LEFT_PARENTHESIS real_operator RIGHT_PARENTHESIS
 
 private tuple ::=
     unit

--- a/src/org/elmlang/intellijplugin/Elm.flex
+++ b/src/org/elmlang/intellijplugin/Elm.flex
@@ -32,7 +32,6 @@ STRING_WITH_QUOTES_LITERAL=\"\"\"(\\.|[^\\\"]|\"{1,2}([^\"\\]|\\\"))*\"\"\"
 NUMBER_LITERAL=("-")?[:digit:]+(\.[:digit:]+)?
 CHAR_LITERAL='(\\.|\\x[[:digit:]A-Fa-f]+|[^\\'])'
 OPERATOR=("!"|"$"|"^"|"|"|"*"|"/"|"?"|"+"|"~"|-|=|@|#|%|&|<|>|:|€|¥|¢|£|¤)+
-BACKTICKED_FUNCTION="`"{LOWER_CASE_IDENTIFIER}"`"
 RESERVED=("hiding" | "export" | "foreign" | "perform" | "deriving")
 
 %%
@@ -165,6 +164,9 @@ RESERVED=("hiding" | "export" | "foreign" | "perform" | "deriving")
     "." {
         return DOT;
     }
+    "`" {
+        return BACKTICK;
+    }
     {CRLF}*"{-" {
         commentLevel = 1;
         yybegin(IN_COMMENT);
@@ -194,7 +196,7 @@ RESERVED=("hiding" | "export" | "foreign" | "perform" | "deriving")
     {CRLF}*{LINE_COMMENT} {
         return LINE_COMMENT;
     }
-    {OPERATOR}|{BACKTICKED_FUNCTION} {
+    {OPERATOR} {
         return OPERATOR;
     }
     {WHITE_SPACE}+ {


### PR DESCRIPTION
This closes #4