### PR TITLE
Expand syntax highlighting

### DIFF
--- a/src/main/java/org/elmlang/intellijplugin/ElmColorSettingsPage.java
+++ b/src/main/java/org/elmlang/intellijplugin/ElmColorSettingsPage.java
@@ -1,0 +1,126 @@
+package org.elmlang.intellijplugin;
+
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.openapi.fileTypes.SyntaxHighlighter;
+import com.intellij.openapi.options.colors.AttributesDescriptor;
+import com.intellij.openapi.options.colors.ColorDescriptor;
+import com.intellij.openapi.options.colors.ColorSettingsPage;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.elmlang.intellijplugin.ElmSyntaxHighlighter.*;
+
+public class ElmColorSettingsPage implements ColorSettingsPage {
+
+    @NonNls
+    private static final Map<String, TextAttributesKey> TAG_HIGHLIGHTING_MAP = new HashMap<String, TextAttributesKey>();
+    static {
+        TAG_HIGHLIGHTING_MAP.put("sig_left", ELM_TYPE_ANNOTATION_NAME);
+        TAG_HIGHLIGHTING_MAP.put("sig_right", ELM_TYPE_ANNOTATION_SIGNATURE_TYPES);
+        TAG_HIGHLIGHTING_MAP.put("type", ELM_TYPE);
+        TAG_HIGHLIGHTING_MAP.put("func_decl", ELM_DEFINITION_NAME);
+    }
+
+    private static final AttributesDescriptor[] ATTRIBS = {
+            new AttributesDescriptor("Keyword", ELM_KEYWORD),
+            new AttributesDescriptor("Number", ELM_NUMBER),
+            new AttributesDescriptor("String", ELM_STRING),
+            new AttributesDescriptor("Operator", ELM_OPERATOR),
+            new AttributesDescriptor("Type", ELM_TYPE),
+            new AttributesDescriptor("Definition Name", ELM_DEFINITION_NAME),
+            new AttributesDescriptor("Type Annotation//Name", ELM_TYPE_ANNOTATION_NAME),
+            new AttributesDescriptor("Type Annotation//Signature", ELM_TYPE_ANNOTATION_SIGNATURE_TYPES),
+            new AttributesDescriptor("Punctuation//Arrows", ELM_ARROW),
+            new AttributesDescriptor("Punctuation//Parentheses", ELM_PARENTHESIS),
+            new AttributesDescriptor("Punctuation//Braces", ELM_BRACES),
+            new AttributesDescriptor("Punctuation//Brackets", ELM_BRACKETS),
+            new AttributesDescriptor("Punctuation//Comma", ELM_COMMA),
+            new AttributesDescriptor("Punctuation//Dot", ELM_DOT),
+            new AttributesDescriptor("Punctuation//Equals", ELM_EQ),
+            new AttributesDescriptor("Punctuation//Pipe", ELM_PIPE),
+    };
+
+    @NotNull
+    @Override
+    public AttributesDescriptor[] getAttributeDescriptors() {
+        return ATTRIBS;
+    }
+
+    @NotNull
+    @Override
+    public ColorDescriptor[] getColorDescriptors() {
+        return ColorDescriptor.EMPTY_ARRAY;
+    }
+
+    @NotNull
+    @Override
+    public String getDisplayName() {
+        return "Elm";
+    }
+
+    @Nullable
+    @Override
+    public Icon getIcon() {
+        return ElmIcons.FILE;
+    }
+
+    @NotNull
+    @Override
+    public SyntaxHighlighter getHighlighter() {
+        return new ElmSyntaxHighlighter();
+    }
+
+    @NotNull
+    @Override
+    public String getDemoText() {
+        return "module Todo exposing (..)\n" +
+                "\n" +
+                "import Html exposing (div, h1, ul, li, text)\n" +
+                "\n" +
+                "-- a single line comment\n" +
+                "\n" +
+                "type alias <type>Model</type> =\n" +
+                "    { page : <type>Int</type>\n" +
+                "    , title : <type>String</type>\n" +
+                "    , stepper : <type>Int</type> -> <type>Int</type>\n" +
+                "    }\n" +
+                "\n" +
+                "type <type>Msg</type>\n" +
+                "    = ModeA\n" +
+                "    | ModeB <type>Int</type>\n" +
+                "\n" +
+                "<sig_left>update</sig_left> : <sig_right>Msg</sig_right> -> <sig_right>Model</sig_right> -> ( <sig_right>Model</sig_right>, <sig_right>Cmd Msg</sig_right> )\n" +
+                "<func_decl>update</func_decl> msg model =\n" +
+                "  case msg of\n" +
+                "    ModeA ->\n" +
+                "      { model\n" +
+                "        | page = 0\n" +
+                "        , title = \"Mode A\"\n" +
+                "        , stepper = (\\k -> k + 1)\n" +
+                "      }\n" +
+                "        ! []\n" +
+                "\n" +
+                "<sig_left>view</sig_left> : <sig_right>Model</sig_right> -> <sig_right>Html.Html Msg</sig_right>\n" +
+                "<func_decl>view</func_decl> model =\n" +
+                "  let\n" +
+                "    itemify label =\n" +
+                "      li [] [ text label ]\n" +
+                "  in\n" +
+                "    div []\n" +
+                "      [ h1 [] [ text \"Chapter One\" ]\n" +
+                "      , ul []\n" +
+                "          (List.map itemify model.items)\n" +
+                "      ]\n";
+}
+
+    @Nullable
+    @Override
+    public Map<String, TextAttributesKey> getAdditionalHighlightingTagToDescriptorMap() {
+        return TAG_HIGHLIGHTING_MAP;
+    }
+}

--- a/src/main/java/org/elmlang/intellijplugin/ElmSyntaxHighlightAnnotator.java
+++ b/src/main/java/org/elmlang/intellijplugin/ElmSyntaxHighlightAnnotator.java
@@ -1,0 +1,73 @@
+package org.elmlang.intellijplugin;
+
+import com.intellij.lang.annotation.Annotation;
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.elmlang.intellijplugin.psi.*;
+import org.elmlang.intellijplugin.utils.ListUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.elmlang.intellijplugin.ElmSyntaxHighlighter.*;
+
+
+public class ElmSyntaxHighlightAnnotator implements Annotator {
+
+    @Override
+    public void annotate(@NotNull PsiElement element, @NotNull AnnotationHolder holder) {
+
+        if (element instanceof ElmValueDeclaration) {
+            highlightValueDeclaration(holder, (ElmValueDeclaration) element);
+
+        } else if (element instanceof ElmTypeAnnotation) {
+            highlightTypeAnnotation(holder, (ElmTypeAnnotation) element);
+
+        } else if (element instanceof ElmUpperCaseId
+                && (PsiTreeUtil.getParentOfType(element, ElmTypeAnnotation.class,
+                        ElmModuleDeclaration.class, ElmImportClause.class) == null)) {
+            highlightElement(holder, element, ELM_TYPE);
+
+        } else if (element instanceof ElmBacktickedFunction) {
+            highlightElement(holder, element, ELM_OPERATOR);
+        }
+    }
+
+    private void highlightValueDeclaration(@NotNull AnnotationHolder holder, @NotNull ElmValueDeclaration declaration) {
+        // First try treating it as a function declaration
+        ElmLowerCaseId nameElement = Optional.ofNullable(declaration.getFunctionDeclarationLeft())
+                .map(ElmFunctionDeclarationLeft::getLowerCaseId)
+                .orElse(null);
+
+        // Fallback to a generic (null-ary) value declaration
+        if (nameElement == null) {
+            nameElement = Optional.ofNullable(declaration.getPattern())
+                    .flatMap(p -> ListUtils.head(p.getLowerCaseIdList()))
+                    .orElse(null);
+        }
+
+        if (nameElement != null) {
+            highlightElement(holder, nameElement, ELM_DEFINITION_NAME);
+        }
+    }
+
+    private void highlightTypeAnnotation(@NotNull AnnotationHolder holder, @NotNull ElmTypeAnnotation typeAnnotation) {
+        Optional.ofNullable(typeAnnotation.getLowerCaseId())
+                .ifPresent(e -> highlightElement(holder, e, ELM_TYPE_ANNOTATION_NAME));
+
+        ElmTypeDefinition typeDefinition = typeAnnotation.getTypeDefinition();
+        Stream.concat(
+                PsiTreeUtil.findChildrenOfType(typeDefinition, ElmLowerCaseId.class).stream(),
+                PsiTreeUtil.findChildrenOfType(typeDefinition, ElmUpperCaseId.class).stream())
+                .forEach(elt -> highlightElement(holder, elt, ELM_TYPE_ANNOTATION_SIGNATURE_TYPES));
+    }
+
+    private void highlightElement(@NotNull AnnotationHolder holder, @NotNull PsiElement element, TextAttributesKey key) {
+        Annotation annotation = holder.createInfoAnnotation(element, null);
+        annotation.setTextAttributes(key);
+    }
+}

--- a/src/main/java/org/elmlang/intellijplugin/ElmSyntaxHighlighter.java
+++ b/src/main/java/org/elmlang/intellijplugin/ElmSyntaxHighlighter.java
@@ -10,30 +10,90 @@ import com.intellij.psi.TokenType;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
 import org.jetbrains.annotations.NotNull;
-import static org.elmlang.intellijplugin.psi.ElmTypes.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.intellij.openapi.editor.colors.TextAttributesKey.createTextAttributesKey;
+import static org.elmlang.intellijplugin.psi.ElmTypes.*;
+
 
 public class ElmSyntaxHighlighter extends SyntaxHighlighterBase {
-    private static final TextAttributesKey[] KEYWORD_KEYS = new TextAttributesKey[] {
-        createTextAttributesKey("ELM_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD)
-    };
-    private static final TextAttributesKey[] BAD_CHAR_KEYS = new TextAttributesKey[] {
-        createTextAttributesKey("ELM_BAD_CHARACTER", HighlighterColors.BAD_CHARACTER)
-    };
-    private static final TextAttributesKey[] COMMENT_KEYS = new TextAttributesKey[] {
-        createTextAttributesKey("ELM_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT)
-    };
-    private static final TextAttributesKey[] STRING_KEYS = new TextAttributesKey[] {
-        createTextAttributesKey("ELM_STRING", DefaultLanguageHighlighterColors.STRING)
-    };
-    private static final TextAttributesKey[] NUMBER_KEYS = new TextAttributesKey[] {
-            createTextAttributesKey("ELM_NUMBER", DefaultLanguageHighlighterColors.NUMBER)
-    };
-    private static final TextAttributesKey[] PARENTHESIS_KEYS = new TextAttributesKey[] {
-        createTextAttributesKey("ELM_PARENTHESIS", DefaultLanguageHighlighterColors.PARENTHESES)
-    };
-    private static final TextAttributesKey[] EMPTY_KEYS = new TextAttributesKey[0];
+
+    public static final TextAttributesKey ELM_KEYWORD =
+            createTextAttributesKey("ELM_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD);
+
+    public static final TextAttributesKey ELM_BAD_CHAR =
+            createTextAttributesKey("ELM_BAD_CHARACTER", HighlighterColors.BAD_CHARACTER);
+
+    public static final TextAttributesKey ELM_COMMENT =
+            createTextAttributesKey("ELM_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT);
+
+    public static final TextAttributesKey ELM_STRING =
+            createTextAttributesKey("ELM_STRING", DefaultLanguageHighlighterColors.STRING);
+
+    public static final TextAttributesKey ELM_NUMBER =
+            createTextAttributesKey("ELM_NUMBER", DefaultLanguageHighlighterColors.NUMBER);
+
+    public static final TextAttributesKey ELM_DOT =
+            createTextAttributesKey("ELM_DOT", DefaultLanguageHighlighterColors.DOT);
+
+    public static final TextAttributesKey ELM_ARROW =
+            createTextAttributesKey("ELM_ARROW", DefaultLanguageHighlighterColors.OPERATION_SIGN);
+
+    public static final TextAttributesKey ELM_OPERATOR =
+            createTextAttributesKey("ELM_OPERATOR", DefaultLanguageHighlighterColors.OPERATION_SIGN);
+
+    public static final TextAttributesKey ELM_PARENTHESIS =
+            createTextAttributesKey("ELM_PARENTHESIS", DefaultLanguageHighlighterColors.PARENTHESES);
+
+    public static final TextAttributesKey ELM_BRACES =
+            createTextAttributesKey("ELM_BRACES", DefaultLanguageHighlighterColors.BRACES);
+
+    public static final TextAttributesKey ELM_BRACKETS =
+            createTextAttributesKey("ELM_BRACKETS", DefaultLanguageHighlighterColors.BRACKETS);
+
+    public static final TextAttributesKey ELM_COMMA =
+            createTextAttributesKey("ELM_COMMA", DefaultLanguageHighlighterColors.COMMA);
+
+    public static final TextAttributesKey ELM_EQ =
+            createTextAttributesKey("ELM_EQ", DefaultLanguageHighlighterColors.OPERATION_SIGN);
+
+    public static final TextAttributesKey ELM_PIPE =
+            createTextAttributesKey("ELM_PIPE", DefaultLanguageHighlighterColors.OPERATION_SIGN);
+
+    /**
+     * The name of a definition.
+     *
+     * e.g. 'foo' in 'foo x y = x * y'
+     */
+    public static final TextAttributesKey ELM_DEFINITION_NAME =
+            createTextAttributesKey("ELM_DEFINITION_NAME", DefaultLanguageHighlighterColors.FUNCTION_DECLARATION);
+
+    /**
+     * The uppercase identifier for a type in all contexts EXCEPT when appearing
+     * in a type annotation.
+     */
+    public static final TextAttributesKey ELM_TYPE =
+            createTextAttributesKey("ELM_TYPE", DefaultLanguageHighlighterColors.CLASS_NAME);
+
+    /**
+     * The lowercase identifier name in a type annotation.
+     *
+     * e.g. 'foo' in 'foo : String -> Cmd msg'
+     */
+    public static final TextAttributesKey ELM_TYPE_ANNOTATION_NAME =
+            createTextAttributesKey("ELM_TYPE_ANNOTATION_NAME", DefaultLanguageHighlighterColors.FUNCTION_DECLARATION);
+
+    /**
+     * Both uppercase and lowercase identifiers appearing on the right-hand side
+     * of a top-level type annotation.
+     *
+     * e.g. 'String' and 'Cmd msg' in 'foo : String -> Cmd msg'
+     */
+    public static final TextAttributesKey ELM_TYPE_ANNOTATION_SIGNATURE_TYPES =
+            createTextAttributesKey("ELM_TYPE_ANNOTATION_SIGNATURE_TYPES", DefaultLanguageHighlighterColors.CLASS_REFERENCE);
+
 
     private static final TokenSet KEYWORDS = TokenSet.create(
             WHERE,
@@ -67,6 +127,16 @@ public class ElmSyntaxHighlighter extends SyntaxHighlighterBase {
             RIGHT_PARENTHESIS
     );
 
+    private static final TokenSet BRACES = TokenSet.create(
+            LEFT_BRACE,
+            RIGHT_BRACE
+    );
+
+    private static final TokenSet BRACKETS = TokenSet.create(
+            LEFT_SQUARE_BRACKET,
+            RIGHT_SQUARE_BRACKET
+    );
+
     private static final TokenSet COMMENTS = TokenSet.create(
             LINE_COMMENT,
             START_COMMENT,
@@ -74,29 +144,40 @@ public class ElmSyntaxHighlighter extends SyntaxHighlighterBase {
             COMMENT_CONTENT
     );
 
-    @NotNull
-    @Override
-    public Lexer getHighlightingLexer() {
-        return new ElmLexerAdapter();
+    private static final TokenSet OPERATORS = TokenSet.create(
+            OPERATOR,
+            LIST_CONSTRUCTOR
+    );
+
+    private static Map<IElementType, TextAttributesKey>keys;
+
+    static {
+        keys = new HashMap<IElementType, TextAttributesKey>();
+        fillMap(keys, KEYWORDS, ELM_KEYWORD);
+        fillMap(keys, STRINGS, ELM_STRING);
+        fillMap(keys, COMMENTS, ELM_COMMENT);
+        fillMap(keys, PARENTHESES, ELM_PARENTHESIS);
+        fillMap(keys, BRACES, ELM_BRACES);
+        fillMap(keys, BRACKETS, ELM_BRACKETS);
+        fillMap(keys, OPERATORS, ELM_OPERATOR);
+        keys.put(ARROW, ELM_ARROW);
+        keys.put(EQ, ELM_EQ);
+        keys.put(COMMA, ELM_COMMA);
+        keys.put(DOT, ELM_DOT);
+        keys.put(NUMBER_LITERAL, ELM_NUMBER);
+        keys.put(PIPE, ELM_PIPE);
+        keys.put(TokenType.BAD_CHARACTER, ELM_BAD_CHAR);
     }
 
     @NotNull
     @Override
     public TextAttributesKey[] getTokenHighlights(IElementType tokenType) {
-        if (KEYWORDS.contains(tokenType)) {
-            return KEYWORD_KEYS;
-        } else if (PARENTHESES.contains(tokenType)) {
-            return PARENTHESIS_KEYS;
-        } else if (COMMENTS.contains(tokenType)) {
-            return COMMENT_KEYS;
-        } else if (STRINGS.contains(tokenType)) {
-            return STRING_KEYS;
-        } else if (tokenType.equals(NUMBER_LITERAL)) {
-            return NUMBER_KEYS;
-        } else if (tokenType.equals(TokenType.BAD_CHARACTER)) {
-            return BAD_CHAR_KEYS;
-        } else {
-            return EMPTY_KEYS;
-        }
+        return pack(keys.get(tokenType));
+    }
+
+    @NotNull
+    @Override
+    public Lexer getHighlightingLexer() {
+        return new ElmLexerAdapter();
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -77,6 +77,11 @@
         <lang.syntaxHighlighterFactory
                 language="Elm"
                 implementationClass="org.elmlang.intellijplugin.ElmSyntaxHighlighterFactory"/>
+        <annotator
+                language="Elm"
+                implementationClass="org.elmlang.intellijplugin.ElmSyntaxHighlightAnnotator"/>
+        <colorSettingsPage
+                implementation="org.elmlang.intellijplugin.ElmColorSettingsPage" />
         <lang.commenter
                 language="Elm"
                 implementationClass="org.elmlang.intellijplugin.features.ElmCommenter"/>
@@ -89,6 +94,8 @@
         <spellchecker.support
                 language="Elm"
                 implementationClass="com.intellij.spellchecker.tokenizer.SpellcheckingStrategy"/>
+        <additionalTextAttributes scheme="Default" file="colorSchemes/ElmDefault.xml"/>
+        <additionalTextAttributes scheme="Darcula" file="colorSchemes/ElmDarcula.xml"/>
     </extensions>
 
     <actions>

--- a/src/main/resources/colorSchemes/ElmDarcula.xml
+++ b/src/main/resources/colorSchemes/ElmDarcula.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list>
+    <option name="ELM_TYPE_ANNOTATION_SIGNATURE_TYPES">
+        <value>
+            <option name="FOREGROUND" value="#68B3C1"/>
+            <option name="FONT_TYPE" value="1"/>
+        </value>
+    </option>
+    <option name="ELM_TYPE">
+        <value>
+            <option name="FOREGROUND" value="#96c876"/>
+        </value>
+    </option>
+
+    <option name="ELM_ARROW">
+        <value>
+            <option name="FOREGROUND" value="#bd6a81"/>
+        </value>
+    </option>
+    <option name="ELM_OPERATOR">
+        <value>
+            <option name="FOREGROUND" value="#bd6a81"/>
+        </value>
+    </option>
+
+    <!--
+        Elm standard style does a lot of grouping and
+        left-alignment of lines using punctuation. So
+        we set these punctuation elements to the same color
+        so that it reads nicely as a single column.
+    -->
+    <option name="ELM_PARENTHESIS">
+        <value>
+            <option name="FOREGROUND" value="#67a5c7"/>
+        </value>
+    </option>
+    <option name="ELM_BRACES">
+        <value>
+            <option name="FOREGROUND" value="#67a5c7"/>
+        </value>
+    </option>
+    <option name="ELM_BRACKETS">
+        <value>
+            <option name="FOREGROUND" value="#67a5c7"/>
+        </value>
+    </option>
+    <option name="ELM_COMMA">
+        <value>
+            <option name="FOREGROUND" value="#67a5c7"/>
+        </value>
+    </option>
+    <option name="ELM_PIPE">
+        <value>
+            <option name="FOREGROUND" value="#67a5c7"/>
+        </value>
+    </option>
+    <option name="ELM_EQ">
+        <value>
+            <option name="FOREGROUND" value="#67a5c7"/>
+        </value>
+    </option>
+</list>

--- a/src/main/resources/colorSchemes/ElmDefault.xml
+++ b/src/main/resources/colorSchemes/ElmDefault.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list>
+    <option name="ELM_DEFINITION_NAME">
+        <value>
+            <option name="FOREGROUND" value="#333333"/>
+            <option name="FONT_TYPE" value="1"/>
+        </value>
+    </option>
+    <option name="ELM_TYPE_ANNOTATION_NAME">
+        <value>
+            <option name="FOREGROUND" value="#333333"/>
+            <option name="FONT_TYPE" value="1"/>
+        </value>
+    </option>
+    <option name="ELM_TYPE_ANNOTATION_SIGNATURE_TYPES">
+        <value>
+            <option name="FOREGROUND" value="#127b7e"/>
+            <option name="FONT_TYPE" value="1"/>
+        </value>
+    </option>
+    <option name="ELM_TYPE">
+        <value>
+            <option name="FOREGROUND" value="#604578"/>
+            <option name="FONT_TYPE" value="1"/>
+        </value>
+    </option>
+
+    <option name="ELM_ARROW">
+        <value>
+            <option name="FOREGROUND" value="#bd6a81"/>
+        </value>
+    </option>
+    <option name="ELM_OPERATOR">
+        <value>
+            <option name="FOREGROUND" value="#bd6a81"/>
+        </value>
+    </option>
+
+    <!--
+        Elm standard style does a lot of grouping and
+        left-alignment of lines using punctuation. So
+        we set these punctuation elements to the same color
+        so that it reads nicely as a single column.
+    -->
+    <option name="ELM_PARENTHESIS">
+        <value>
+            <option name="FOREGROUND" value="#47748D"/>
+        </value>
+    </option>
+    <option name="ELM_BRACES">
+        <value>
+            <option name="FOREGROUND" value="#47748D"/>
+        </value>
+    </option>
+    <option name="ELM_BRACKETS">
+        <value>
+            <option name="FOREGROUND" value="#47748D"/>
+        </value>
+    </option>
+    <option name="ELM_COMMA">
+        <value>
+            <option name="FOREGROUND" value="#47748D"/>
+        </value>
+    </option>
+    <option name="ELM_PIPE">
+        <value>
+            <option name="FOREGROUND" value="#47748D"/>
+        </value>
+    </option>
+    <option name="ELM_EQ">
+        <value>
+            <option name="FOREGROUND" value="#47748D"/>
+        </value>
+    </option>
+</list>


### PR DESCRIPTION
_(same as previous PR but targeting the correct branch in the base repo)_

Improves the syntax highlighting so that more elements are highlighted by-default and provides a Color Settings screen.
## Examples

Darcula
<img width="436" alt="darcula example" src="https://cloud.githubusercontent.com/assets/84525/16340788/d28eab2a-39de-11e6-870f-ae8f461efa77.png">
Default
<img width="454" alt="default example" src="https://cloud.githubusercontent.com/assets/84525/16340791/d5767dfe-39de-11e6-810d-6655fd0f3c39.png">
## Configuration

<img width="998" alt="screen shot 2016-06-24 at 7 41 29 am" src="https://cloud.githubusercontent.com/assets/84525/16340867/288997ec-39df-11e6-8430-18d159cee4e2.png">
## Further Work

One thing that I'd like to improve is the highlighting of upper-case identifiers. I'd like to differentiate further between Types, the tags on unions, and modules. 
