### PR TITLE
Add quick-fix for unresolved references by adding an import statement

### DIFF
--- a/src/main/java/org/elmlang/intellijplugin/features/intention/imports/ElmAddImportHelper.java
+++ b/src/main/java/org/elmlang/intellijplugin/features/intention/imports/ElmAddImportHelper.java
@@ -1,0 +1,199 @@
+package org.elmlang.intellijplugin.features.intention.imports;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiComment;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.elmlang.intellijplugin.psi.*;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ElmAddImportHelper {
+    private ElmAddImportHelper() {
+    }
+
+    public static void addOrUpdateImport(ElmFile sourceFile, String moduleName, @Nullable String nameToImport, boolean importAsQualified) {
+        Project project = sourceFile.getProject();
+
+        // Create a new, stand-alone import based solely on the quick-fix
+        ElmImportClause newImport = importAsQualified
+                ? ElmElementFactory.createImport(project, moduleName)
+                : ElmElementFactory.createImportExposing(project, moduleName, nameToImport);
+
+        // If there are any existing imports for the same module, merge with it
+        Optional<ElmImportClause> existingImportClause = sourceFile.getImportClauseByModuleName(moduleName);
+        if (existingImportClause.isPresent()) {
+            // merge with existing import
+            ElmImportClause oldImport = existingImportClause.get();
+            ElmImportClause mergedImport = mergeImports(sourceFile, oldImport, newImport);
+            oldImport.replace(mergedImport);
+        } else {
+            // insert a new import clause
+            ASTNode insertPosition = getInsertPosition(sourceFile, moduleName);
+            insertImportClause(newImport, insertPosition);
+        }
+    }
+
+    private static ElmImportClause mergeImports(ElmFile sourceFile, ElmImportClause import1, ElmImportClause import2) {
+        assert Objects.equals(import1.getModuleName().getText(),
+                              import2.getModuleName().getText());
+
+        Project project = sourceFile.getProject();
+
+        // If either one of the imports has an alias clause, extract it
+        // for use in the new, merged import.
+        Optional<ElmAsClause> as1 = Optional.ofNullable(import1.getAsClause());
+        Optional<ElmAsClause> as2 = Optional.ofNullable(import2.getAsClause());
+        String aliasText = Optional.ofNullable(as1.orElse(as2.orElse(null)))
+                .map(e -> " as " + e.getUpperCaseId().getName())
+                .orElse("");
+
+        // Merge the exposing clause(s)
+        Optional<ElmExposingClause> exposing1 = Optional.ofNullable(import1.getExposingClause());
+        Optional<ElmExposingClause> exposing2 = Optional.ofNullable(import2.getExposingClause());
+
+        List<String> exposedValues =
+                Stream.concat(
+                        exposing1.map(e -> e.getLowerCaseIdList().stream()).orElse(Stream.empty()),
+                        exposing2.map(e -> e.getLowerCaseIdList().stream()).orElse(Stream.empty())
+                )
+                .sorted((e1, e2) -> e1.getText().compareTo(e2.getText()))
+                .map(PsiElement::getText)
+                .collect(Collectors.toList());
+
+        Map<String,List<ElmExposedUnion>> exposedUnionsByName =
+                Stream.concat(
+                        exposing1.map(e -> e.getExposedUnionList().stream()).orElse(Stream.empty()),
+                        exposing2.map(e -> e.getExposedUnionList().stream()).orElse(Stream.empty())
+                )
+                .collect(
+                    Collectors.groupingBy(
+                        e -> e.getUpperCaseId().getName()
+                    )
+                );
+
+        List<String> exposedTypes = exposedUnionsByName.entrySet()
+                .stream()
+                .map(entry -> mergeExposedUnionConstructors(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+
+        // combine the new exposing list and sort it
+        List<String> exposedNames = new ArrayList<>();
+        exposedNames.addAll(exposedValues);
+        exposedNames.addAll(exposedTypes);
+        exposedNames.sort(String::compareTo);
+
+        // generate the new, merged import statement
+        String moduleName = import1.getModuleName().getText();
+        String modulePlusAlias = moduleName + aliasText;
+        return ElmElementFactory.createImportExposing(project, modulePlusAlias, exposedNames);
+    }
+
+    private static String mergeExposedUnionConstructors(String typeName, List<ElmExposedUnion> unions) {
+        boolean exposingAll = unions.stream().anyMatch(union -> {
+            ElmExposedUnionConstructors ctors = union.getExposedUnionConstructors();
+            return ctors != null && ctors.isExposingAll();
+        }) ;
+
+        if (exposingAll) {
+            return typeName + "(..)";
+        }
+
+        String body;
+        body = unions.stream()
+                .filter(e -> e.getExposedUnionConstructors() != null)
+                .flatMap(e -> e.getExposedUnionConstructors().getUpperCaseIdList().stream())
+                .sorted((e1, e2) -> {
+                    String type1 = e1.getText();
+                    String type2 = e2.getText();
+                    return type1.compareTo(type2);
+                })
+                .map(e -> e.getName())
+                .collect(Collectors.joining(", "));
+
+        return body.isEmpty() ? typeName : typeName + "(" + body + ")";
+    }
+
+    private static ASTNode getInsertPosition(ElmFile sourceFile, String moduleName) {
+        Project project = sourceFile.getProject();
+        ASTNode insertPosition = null;
+        List<ElmImportClause> existingImportClauses = sourceFile.getImportClauses();
+        if (existingImportClauses.isEmpty()) {
+            // we need to create a new import section
+            PsiElement moduleDecl = sourceFile.getModuleDeclaration().orElse(null);
+
+            if (moduleDecl == null) {
+                // source file does not have an explicit module declaration
+                // so just insert at the front of the file.
+                insertPosition = sourceFile.getNode().getFirstChildNode();
+            } else {
+                // skip over comment blocks
+                PsiElement nextNonCommentSibling = PsiTreeUtil.skipSiblingsForward(moduleDecl, PsiComment.class);
+
+                // insert blanklines flanking the new import section
+                ASTNode newFreshline = ElmElementFactory.createFreshLine(project).getNode();
+                sourceFile.getNode().addChild(newFreshline, nextNonCommentSibling.getNode());
+                ASTNode newFreshline2 = ElmElementFactory.createFreshLine(project).getNode();
+                sourceFile.getNode().addChild(newFreshline2, newFreshline);
+                insertPosition = newFreshline.getTreeNext();
+            }
+        } else {
+            // find the sorted position within the existing import section
+
+            // NOTE: we *assume* that the imports are already sorted and we
+            // do not make any distinction between import groups/sections
+            // (e.g. the practice of putting core libs in the first group,
+            // 3rd party libs in a second group, and project files in the
+            // final group). In the future we will likely want to revisit
+            // this shortcut as it would very frustrating for a developer
+            // who "curates" their import list to keep fighting where the
+            // quick-fix puts its imports.
+            ElmImportClause prevImport = null;
+            for (ElmImportClause currentImport : existingImportClauses) {
+                String a = prevImport == null ? "" : prevImport.getModuleName().getText();
+                String b = currentImport.getModuleName().getText();
+
+                if (a.compareTo(moduleName) < 0 && moduleName.compareTo(b) <= 0) {
+                    insertPosition = currentImport.getNode();
+                    break;
+                }
+                prevImport = currentImport;
+            }
+
+            if (insertPosition == null) {
+                // the new module belongs at the end of the list
+                insertPosition = existingImportClauses.get(existingImportClauses.size() - 1).getNode().getTreeNext();
+            }
+        }
+        return insertPosition;
+    }
+
+    private static void insertImportClause(ElmImportClause importClause, ASTNode insertPosition) {
+        Project project = importClause.getProject();
+        ASTNode parent = insertPosition.getTreeParent();
+        ASTNode beforeInsertPosition = insertPosition.getTreePrev();
+
+        // ensure that a freshline exists immediately following
+        // where we are going to insert the new import clause.
+        ASTNode prevFreshline = null;
+        if (insertPosition.getElementType() != ElmTypes.FRESH_LINE) {
+            prevFreshline = ElmElementFactory.createFreshLine(project).getNode();
+            parent.addChild(prevFreshline, insertPosition);
+        } else {
+            prevFreshline = insertPosition;
+        }
+
+        // insert the import clause before the freshline
+        parent.addChild(importClause.getNode(), prevFreshline);
+
+        // ensure that freshline exists *before* the new import clause
+        if (beforeInsertPosition != null && beforeInsertPosition.getElementType() != ElmTypes.FRESH_LINE) {
+            ASTNode newFreshline = ElmElementFactory.createFreshLine(project).getNode();
+            parent.addChild(newFreshline, importClause.getNode());
+        }
+    }
+}

--- a/src/main/java/org/elmlang/intellijplugin/features/intention/imports/ElmImportCandidate.java
+++ b/src/main/java/org/elmlang/intellijplugin/features/intention/imports/ElmImportCandidate.java
@@ -1,0 +1,36 @@
+package org.elmlang.intellijplugin.features.intention.imports;
+
+import com.intellij.psi.PsiElement;
+
+public class ElmImportCandidate {
+    public final String moduleName;
+    public final String name;
+    public final String nameForImport;
+    public final PsiElement element;
+
+    /**
+     * @param moduleName    the module where this value/type lives
+     * @param name          the name of the value/type
+     * @param nameForImport the name suitable for insert into an exposing clause.
+     *                      Typically this is the same as `name`, but when importing
+     *                      a bare union type member, it will be the parenthesized
+     *                      form: "TypeName(MemberName)"
+     * @param element       the value/type element in the module-to-be-imported
+     */
+    public ElmImportCandidate(String moduleName, String name, String nameForImport, PsiElement element) {
+        this.moduleName = moduleName;
+        this.name = name;
+        this.nameForImport = nameForImport;
+        this.element = element;
+    }
+
+    @Override
+    public String toString() {
+        return "ElmImportCandidate{" +
+                "moduleName='" + moduleName + '\'' +
+                ", name='" + name + '\'' +
+                ", nameForImport='" + nameForImport + '\'' +
+                ", element=" + element +
+                '}';
+    }
+}

--- a/src/main/java/org/elmlang/intellijplugin/features/intention/imports/ElmImportQuickFix.java
+++ b/src/main/java/org/elmlang/intellijplugin/features/intention/imports/ElmImportQuickFix.java
@@ -1,0 +1,163 @@
+package org.elmlang.intellijplugin.features.intention.imports;
+
+import com.intellij.codeInsight.hint.HintManager;
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.psi.PsiFile;
+import com.intellij.ui.components.JBList;
+import com.intellij.util.IncorrectOperationException;
+import org.elmlang.intellijplugin.ElmModuleIndex;
+import org.elmlang.intellijplugin.psi.*;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.*;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ElmImportQuickFix implements IntentionAction {
+
+    private String referenceNameToFix;
+
+    public ElmImportQuickFix(String referenceNameToFix) {
+        this.referenceNameToFix = referenceNameToFix;
+    }
+
+    @Override
+    public String getText() {
+        return "Add Import";
+    }
+
+    @Override
+    public String getFamilyName() {
+        return "style";
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project, Editor editor, PsiFile file) {
+        return true;
+    }
+
+    @Override
+    public boolean startInWriteAction() {
+        return false;
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, Editor editor, PsiFile file) throws IncorrectOperationException {
+        List<String> refComponents = Arrays.asList(referenceNameToFix.split(Pattern.quote(".")));
+
+        List<ElmImportCandidate> candidates = findCandidates(project, refComponents);
+        if (candidates.isEmpty()) {
+            HintManager.getInstance().showErrorHint(editor, "No module exporting '" + referenceNameToFix + "' found");
+        } else if (candidates.size() == 1) {
+            ElmImportCandidate candidate = candidates.get(0);
+            fixWithCandidate(project, (ElmFile) file, refComponents, candidate);
+        } else {
+            List<ElmImportCandidate> sortedCandidates = new ArrayList<>(candidates);
+            sortedCandidates.sort((a,b) -> a.moduleName.compareTo(b.moduleName));
+            promptToSelectCandidate(project, (ElmFile) file, refComponents, sortedCandidates);
+        }
+    }
+
+    private List<ElmImportCandidate> findCandidates(@NotNull Project project, List<String>refComponents) {
+        String refBareName;
+        Stream<String> moduleNames;
+
+        if (refComponents.size() > 1) {
+            refBareName = refComponents.get(refComponents.size()-1);
+            String refQualifiedModuleName = String.join(".", refComponents.subList(0, refComponents.size()-1));
+            moduleNames = Arrays.asList(refQualifiedModuleName).stream();
+        } else {
+            refBareName = referenceNameToFix;
+            moduleNames = ElmModuleIndex.getAllModuleNames(project).stream();
+        }
+
+        final String refBareNameFinal = refBareName;
+
+        if (refBareName.matches("^[A-Z].*")) {
+            // it's an upper-case type or type constructor that we're looking for
+            return moduleNames
+                    .flatMap(name -> ElmModuleIndex.getFilesByModuleName(name, project).stream())
+                    .map(f -> f.getExposedType(refBareNameFinal))
+                    .filter(Optional::isPresent)
+                    .map(e -> {
+                        ElmUpperCaseId value = e.get();
+                        ElmFile module = (ElmFile) value.getContainingFile();
+                        String nameForImport = value.getName();
+                        if (value.getParent() instanceof  ElmUnionMember) {
+                            ElmTypeDeclaration typeDecl = (ElmTypeDeclaration) value.getParent().getParent();
+                            String typeName = typeDecl.getUpperCaseId().getText();
+                            nameForImport = typeName + "(" + value.getName() + ")";
+                        }
+                        return new ElmImportCandidate(
+                                module.getModuleName(),
+                                value.getName(),
+                                nameForImport,
+                                value
+                        );
+                    })
+                    .collect(Collectors.toList());
+        } else {
+            // it's a lower-case value that we're looking for
+            return moduleNames
+                    .flatMap(name -> ElmModuleIndex.getFilesByModuleName(name, project).stream())
+                    .map(f -> f.getExposedValueByName(refBareNameFinal))
+                    .filter(Optional::isPresent)
+                    .map(e -> {
+                        ElmLowerCaseId value = e.get();
+                        ElmFile module = (ElmFile) value.getContainingFile();
+                        String nameForImport = value.getName();
+                        return new ElmImportCandidate(
+                                module.getModuleName(),
+                                value.getName(),
+                                nameForImport,
+                                value
+                        );
+                    })
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private void promptToSelectCandidate(@NotNull final Project project, final ElmFile file, final List<String> refComponents, List<ElmImportCandidate> candidates) {
+        final JBList list = new JBList(candidates);
+        list.setCellRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                Component result = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                @SuppressWarnings("unchecked") ElmImportCandidate candidate = (ElmImportCandidate)value;
+                setText(candidate.moduleName);
+                return result;
+            }
+        });
+        Editor editor = FileEditorManager.getInstance(project).getSelectedTextEditor();
+        JBPopupFactory.getInstance().createListPopupBuilder(list)
+                .setTitle("Import from module:")
+                .setItemChoosenCallback(() -> {
+                    final Object value = list.getSelectedValue();
+                    if (value instanceof ElmImportCandidate) {
+                        ElmImportCandidate candidate = (ElmImportCandidate) value;
+                        fixWithCandidate(project, file, refComponents, candidate);
+                    }
+                })
+                .setFilteringEnabled(value -> ((ElmImportCandidate)value).moduleName)
+                .createPopup().showInBestPositionFor(editor);
+    }
+
+    private void fixWithCandidate(@NotNull final Project project, final ElmFile file, final List<String> refComponents, final ElmImportCandidate candidate) {
+        new WriteCommandAction.Simple(project) {
+            @Override
+            protected void run() throws Throwable {
+                boolean importAsQualified = refComponents.size() > 1;
+                ElmAddImportHelper.addOrUpdateImport(file, candidate.moduleName, candidate.nameForImport, importAsQualified);
+            }
+        }.execute();
+    }
+}

--- a/src/main/java/org/elmlang/intellijplugin/psi/ElmElementFactory.java
+++ b/src/main/java/org/elmlang/intellijplugin/psi/ElmElementFactory.java
@@ -1,11 +1,14 @@
 package org.elmlang.intellijplugin.psi;
 
 import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFileFactory;
 import org.elmlang.intellijplugin.ElmFileType;
 import org.elmlang.intellijplugin.utils.ListUtils;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 public class ElmElementFactory {
@@ -26,6 +29,38 @@ public class ElmElementFactory {
                 .filter(e -> e instanceof ElmValueDeclaration)
                 .flatMap(e -> Optional.ofNullable(((ElmValueDeclaration)e).getPattern()))
                 .flatMap(e -> ListUtils.head(e.getLowerCaseIdList()))
+                .orElse(null);
+    }
+
+    @Nullable
+    public static ElmImportClause createImport(Project project, String moduleName) {
+        final ElmFile file = createFile(project, String.format("import %s", moduleName));
+        return Optional.ofNullable(file.getFirstChild())
+                .filter(e -> e instanceof ElmImportClause)
+                .map(e -> (ElmImportClause) e)
+                .orElse(null);
+    }
+
+    @Nullable
+    public static ElmImportClause createImportExposing(Project project, String moduleName, String valueName) {
+        return createImportExposing(project, moduleName, Arrays.asList(valueName));
+    }
+
+    @Nullable
+    public static ElmImportClause createImportExposing(Project project, String moduleName, List<String> exposedNames) {
+        String contents = String.join(", ", exposedNames);
+        final ElmFile file = createFile(project, String.format("import %s exposing (%s)", moduleName, contents));
+        return Optional.ofNullable(file.getFirstChild())
+                .filter(e -> e instanceof ElmImportClause)
+                .map(e -> (ElmImportClause) e)
+                .orElse(null);
+    }
+
+    @Nullable
+    public static PsiElement createFreshLine(Project project) {
+        final ElmFile file = createFile(project, "\n");
+        return Optional.ofNullable(file.getFirstChild())
+                .filter(e -> e.getNode().getElementType() == ElmTypes.FRESH_LINE)
                 .orElse(null);
     }
 

--- a/src/main/java/org/elmlang/intellijplugin/psi/references/annotation/UnresolvedReferenceAnnotator.java
+++ b/src/main/java/org/elmlang/intellijplugin/psi/references/annotation/UnresolvedReferenceAnnotator.java
@@ -2,6 +2,7 @@ package org.elmlang.intellijplugin.psi.references.annotation;
 
 import com.intellij.lang.annotation.*;
 import com.intellij.psi.*;
+import org.elmlang.intellijplugin.features.intention.imports.ElmImportQuickFix;
 import org.elmlang.intellijplugin.psi.*;
 import org.elmlang.intellijplugin.psi.impl.ElmPsiElement;
 import org.elmlang.intellijplugin.psi.references.ElmReference;
@@ -56,7 +57,9 @@ public class UnresolvedReferenceAnnotator implements Annotator {
                     reference.getCanonicalText(),
                     additionalMessage
             );
-            holder.createErrorAnnotation(reference.getReferencingElement(), message);
+            Annotation annotation = holder.createErrorAnnotation(reference.getReferencingElement(), message);
+            String nameToFix = reference.getReferencingElement().getText();
+            annotation.registerFix(new ElmImportQuickFix(nameToFix));
         }
     }
 }

--- a/src/main/java/org/elmlang/intellijplugin/utils/ListUtils.java
+++ b/src/main/java/org/elmlang/intellijplugin/utils/ListUtils.java
@@ -1,6 +1,7 @@
 package org.elmlang.intellijplugin.utils;
 
 
+import com.intellij.openapi.util.Pair;
 import com.intellij.util.Function;
 
 import java.util.*;
@@ -68,5 +69,14 @@ public class ListUtils {
             }
         }
         return null;
+    }
+
+    public static <T1,T2> List<Pair<T1,T2>> zip(List<T1> list1, List<T2> list2) {
+        int size = Math.min(list1.size(), list2.size());
+        ArrayList<Pair<T1,T2>> result =  new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            result.add(Pair.create(list1.get(i), list2.get(i)));
+        }
+        return result;
     }
 }

--- a/src/test/org/elmlang/intellijplugin/features/intention/imports/ElmImportQuickFixTest.java
+++ b/src/test/org/elmlang/intellijplugin/features/intention/imports/ElmImportQuickFixTest.java
@@ -1,0 +1,89 @@
+package org.elmlang.intellijplugin.features.intention.imports;
+
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
+
+public class ElmImportQuickFixTest extends LightPlatformCodeInsightFixtureTestCase {
+
+    @Override
+    protected String getTestDataPath() {
+        return "src/test/resources/testData/intentions/import";
+    }
+
+    public void testBasic() {
+        myFixture.configureByFiles("Basic.elm", "LibraryA.elm");
+
+        // This code to find the 'quick fix' *should* work, but I get a runtime
+        // assertion "Must not start highlighting from within write action, or deadlock is imminent".
+        // So for the time being, I'm just going to new-up the quick fix myself
+        //
+        //        IntentionAction quickFix = myFixture.findSingleIntention("Add Import");
+
+        ElmImportQuickFix fix = new ElmImportQuickFix("LibraryA.avril14th");
+        myFixture.launchAction(fix);
+        myFixture.checkResultByFile("Basic_after.elm", true);
+    }
+
+    public void testNoModuleDecl() {
+        myFixture.configureByFiles("NoModuleDecl.elm", "LibraryA.elm");
+        myFixture.launchAction(new ElmImportQuickFix("LibraryA.avril14th"));
+        myFixture.checkResultByFile("NoModuleDecl_after.elm", true);
+    }
+
+    public void testExposing() {
+        myFixture.configureByFiles("Exposing.elm", "LibraryA.elm");
+        myFixture.launchAction(new ElmImportQuickFix("ageispolis"));
+        myFixture.launchAction(new ElmImportQuickFix("avril14th"));
+        myFixture.launchAction(new ElmImportQuickFix("actium"));
+        myFixture.checkResultByFile("Exposing_after.elm", true);
+    }
+
+    public void testMixed() {
+        myFixture.configureByFiles("Mixed.elm", "LibraryA.elm");
+        myFixture.launchAction(new ElmImportQuickFix("LibraryA.ageispolis"));
+        myFixture.launchAction(new ElmImportQuickFix("avril14th"));
+        myFixture.launchAction(new ElmImportQuickFix("actium"));
+        myFixture.checkResultByFile("Mixed_after.elm", true);
+    }
+
+    public void testAliased() {
+        myFixture.configureByFiles("Aliased.elm", "LibraryA.elm");
+        myFixture.launchAction(new ElmImportQuickFix("avril14th"));
+        myFixture.checkResultByFile("Aliased_after.elm", true);
+    }
+
+    public void testHasModuleComment() {
+        myFixture.configureByFiles("HasModuleComment.elm", "LibraryA.elm");
+        myFixture.launchAction(new ElmImportQuickFix("LibraryA.avril14th"));
+        myFixture.checkResultByFile("HasModuleComment_after.elm", true);
+    }
+
+    public void testSortedMulti() {
+        myFixture.configureByFiles("SortedMulti.elm", "LibraryA.elm", "LibraryB.elm", "LibraryC.elm");
+        myFixture.launchAction(new ElmImportQuickFix("LibraryB.beCool"));
+        myFixture.launchAction(new ElmImportQuickFix("LibraryC.calamity"));
+        myFixture.launchAction(new ElmImportQuickFix("LibraryA.avril14th"));
+        myFixture.checkResultByFile("SortedMulti_after.elm", true);
+    }
+
+    public void testExposedUnionConstructor() {
+        myFixture.configureByFiles("ExposedUnionConstructor.elm", "LibraryTypes.elm");
+        myFixture.launchAction(new ElmImportQuickFix("NonModal"));
+        myFixture.launchAction(new ElmImportQuickFix("Modal"));
+        myFixture.launchAction(new ElmImportQuickFix("Overlay"));
+        myFixture.checkResultByFile("ExposedUnionConstructor_after.elm", true);
+    }
+
+    public void testTypes() {
+        myFixture.configureByFiles("Types.elm", "LibraryTypes.elm");
+        myFixture.launchAction(new ElmImportQuickFix("LibraryTypes.Modal"));
+        myFixture.launchAction(new ElmImportQuickFix("Behavior"));
+        myFixture.launchAction(new ElmImportQuickFix("Overlay"));
+        myFixture.launchAction(new ElmImportQuickFix("Modal"));
+        myFixture.launchAction(new ElmImportQuickFix("NonModal"));
+        myFixture.launchAction(new ElmImportQuickFix("Nonsense"));
+        myFixture.launchAction(new ElmImportQuickFix("makeNonsense"));
+        myFixture.launchAction(new ElmImportQuickFix("nonsenseToString"));
+        myFixture.launchAction(new ElmImportQuickFix("MyModel"));
+        myFixture.checkResultByFile("Types_after.elm", true);
+    }
+}

--- a/src/test/resources/testData/intentions/import/Aliased.elm
+++ b/src/test/resources/testData/intentions/import/Aliased.elm
@@ -1,0 +1,9 @@
+module Main where
+
+import LibraryA as A
+
+main =
+    text "Cool songs: "
+        ++ A.ageispolis
+        ++ ", "
+        ++ avril14th

--- a/src/test/resources/testData/intentions/import/Aliased_after.elm
+++ b/src/test/resources/testData/intentions/import/Aliased_after.elm
@@ -1,0 +1,9 @@
+module Main where
+
+import LibraryA as A exposing (avril14th)
+
+main =
+    text "Cool songs: "
+        ++ A.ageispolis
+        ++ ", "
+        ++ avril14th

--- a/src/test/resources/testData/intentions/import/Basic.elm
+++ b/src/test/resources/testData/intentions/import/Basic.elm
@@ -1,0 +1,4 @@
+module Main where
+
+main =
+    text LibraryA.avril14th

--- a/src/test/resources/testData/intentions/import/Basic_after.elm
+++ b/src/test/resources/testData/intentions/import/Basic_after.elm
@@ -1,0 +1,6 @@
+module Main where
+
+import LibraryA
+
+main =
+    text LibraryA.avril14th

--- a/src/test/resources/testData/intentions/import/ExposedUnionConstructor.elm
+++ b/src/test/resources/testData/intentions/import/ExposedUnionConstructor.elm
@@ -1,0 +1,13 @@
+module ExposedUnionMember where
+
+main =
+    text "Stuff: "
+        ++ (behaviorToString LibraryTypes.Modal)
+
+
+behaviorToString : Behavior -> String
+behaviorToString behavior =
+    case behavior of
+        Overlay -> "Overlay"
+        Modal -> "Modal"
+        NonModal -> "NonModal"

--- a/src/test/resources/testData/intentions/import/ExposedUnionConstructor_after.elm
+++ b/src/test/resources/testData/intentions/import/ExposedUnionConstructor_after.elm
@@ -1,0 +1,15 @@
+module ExposedUnionMember where
+
+import LibraryTypes exposing (Behavior(Modal, NonModal, Overlay))
+
+main =
+    text "Stuff: "
+        ++ (behaviorToString LibraryTypes.Modal)
+
+
+behaviorToString : Behavior -> String
+behaviorToString behavior =
+    case behavior of
+        Overlay -> "Overlay"
+        Modal -> "Modal"
+        NonModal -> "NonModal"

--- a/src/test/resources/testData/intentions/import/Exposing.elm
+++ b/src/test/resources/testData/intentions/import/Exposing.elm
@@ -1,0 +1,9 @@
+module Main where
+
+main =
+    text "Cool songs: "
+        ++ ageispolis
+        ++ ", "
+        ++ avril14th
+        ++ ", "
+        ++ actium

--- a/src/test/resources/testData/intentions/import/Exposing_after.elm
+++ b/src/test/resources/testData/intentions/import/Exposing_after.elm
@@ -1,0 +1,11 @@
+module Main where
+
+import LibraryA exposing (actium, ageispolis, avril14th)
+
+main =
+    text "Cool songs: "
+        ++ ageispolis
+        ++ ", "
+        ++ avril14th
+        ++ ", "
+        ++ actium

--- a/src/test/resources/testData/intentions/import/HasModuleComment.elm
+++ b/src/test/resources/testData/intentions/import/HasModuleComment.elm
@@ -1,0 +1,9 @@
+module Main where
+
+{-| This is the documentation for module Main.
+
+Imports should appear *below* this comment block.
+-}
+
+main =
+    text LibraryA.avril14th

--- a/src/test/resources/testData/intentions/import/HasModuleComment_after.elm
+++ b/src/test/resources/testData/intentions/import/HasModuleComment_after.elm
@@ -1,0 +1,11 @@
+module Main where
+
+{-| This is the documentation for module Main.
+
+Imports should appear *below* this comment block.
+-}
+
+import LibraryA
+
+main =
+    text LibraryA.avril14th

--- a/src/test/resources/testData/intentions/import/LibraryA.elm
+++ b/src/test/resources/testData/intentions/import/LibraryA.elm
@@ -1,0 +1,7 @@
+module LibraryA (ageispolis, avril14th, actium) where
+
+ageispolis = "Ageispolis"
+
+avril14th = "Avril 14th"
+
+actium = "Actium"

--- a/src/test/resources/testData/intentions/import/LibraryB.elm
+++ b/src/test/resources/testData/intentions/import/LibraryB.elm
@@ -1,0 +1,7 @@
+module LibraryB (beCool, beHereNow, bee) where
+
+beCool = "be cool"
+
+beHereNow = "be here now"
+
+bee = "bee"

--- a/src/test/resources/testData/intentions/import/LibraryC.elm
+++ b/src/test/resources/testData/intentions/import/LibraryC.elm
@@ -1,0 +1,7 @@
+module LibraryC (calamity, cauliflower, caper) where
+
+calamity = "calamity"
+
+cauliflow = "cauliflow"
+
+caper = "caper"

--- a/src/test/resources/testData/intentions/import/LibraryTypes.elm
+++ b/src/test/resources/testData/intentions/import/LibraryTypes.elm
@@ -1,0 +1,42 @@
+module LibraryTypes
+    ( Action(..)
+    , Behavior(..)
+    , MyModel
+    , Nonsense
+    , makeNonsense
+    , nonsenseToString
+    )
+    where
+
+type alias MyModel =
+    { title : String
+    , subTitle : String
+    }
+
+type Action
+    = Abscond
+    | Believe
+    | Cherish
+    | Delve
+
+
+type Behavior
+    = Modal
+    | NonModal
+    | Overlay
+
+
+-- an opaque type
+type Nonsense
+    = Foo
+    | Bar
+
+makeNonsense : Int -> Nonsense
+makeNonsense k =
+    if k == 0 then Foo else Bar
+
+nonsenseToString : Nonsense -> String
+nonsenseToString nonsense =
+    case nonsense of
+        Foo -> "Foo"
+        Bar -> "Bar"

--- a/src/test/resources/testData/intentions/import/Mixed.elm
+++ b/src/test/resources/testData/intentions/import/Mixed.elm
@@ -1,0 +1,9 @@
+module Main where
+
+main =
+    text "Cool songs: "
+        ++ LibraryA.ageispolis
+        ++ ", "
+        ++ avril14th
+        ++ ", "
+        ++ actium

--- a/src/test/resources/testData/intentions/import/Mixed_after.elm
+++ b/src/test/resources/testData/intentions/import/Mixed_after.elm
@@ -1,0 +1,11 @@
+module Main where
+
+import LibraryA exposing (actium, avril14th)
+
+main =
+    text "Cool songs: "
+        ++ LibraryA.ageispolis
+        ++ ", "
+        ++ avril14th
+        ++ ", "
+        ++ actium

--- a/src/test/resources/testData/intentions/import/NoModuleDecl.elm
+++ b/src/test/resources/testData/intentions/import/NoModuleDecl.elm
@@ -1,0 +1,2 @@
+main =
+    text LibraryA.avril14th

--- a/src/test/resources/testData/intentions/import/NoModuleDecl_after.elm
+++ b/src/test/resources/testData/intentions/import/NoModuleDecl_after.elm
@@ -1,0 +1,3 @@
+import LibraryA
+main =
+    text LibraryA.avril14th

--- a/src/test/resources/testData/intentions/import/SortedMulti.elm
+++ b/src/test/resources/testData/intentions/import/SortedMulti.elm
@@ -1,0 +1,9 @@
+module Main where
+
+main =
+    text "Stuff: "
+        ++ LibraryB.beCool
+        ++ ", "
+        ++ LibraryC.calamity
+        ++ ", "
+        ++ LibraryA.avril14th

--- a/src/test/resources/testData/intentions/import/SortedMulti_after.elm
+++ b/src/test/resources/testData/intentions/import/SortedMulti_after.elm
@@ -1,0 +1,13 @@
+module Main where
+
+import LibraryA
+import LibraryB
+import LibraryC
+
+main =
+    text "Stuff: "
+        ++ LibraryB.beCool
+        ++ ", "
+        ++ LibraryC.calamity
+        ++ ", "
+        ++ LibraryA.avril14th

--- a/src/test/resources/testData/intentions/import/Types.elm
+++ b/src/test/resources/testData/intentions/import/Types.elm
@@ -1,0 +1,23 @@
+module Types where
+
+main =
+    text "Stuff: "
+        ++ (behaviorToString LibraryTypes.Modal)
+        ++ ", "
+        ++ (nonsenseToString someNonsense)
+
+behaviorToString : Behavior -> String
+behaviorToString behavior =
+    case behavior of
+        Overlay -> "Overlay"
+        Modal -> "Modal"
+        NonModal -> "NonModal"
+
+
+someNonsense : Nonsense
+someNonsense = makeNonsense 99
+
+
+title : MyModel -> String
+title model =
+    model.title

--- a/src/test/resources/testData/intentions/import/Types_after.elm
+++ b/src/test/resources/testData/intentions/import/Types_after.elm
@@ -1,0 +1,25 @@
+module Types where
+
+import LibraryTypes exposing (Behavior(Modal, NonModal, Overlay), MyModel, Nonsense, makeNonsense, nonsenseToString)
+
+main =
+    text "Stuff: "
+        ++ (behaviorToString LibraryTypes.Modal)
+        ++ ", "
+        ++ (nonsenseToString someNonsense)
+
+behaviorToString : Behavior -> String
+behaviorToString behavior =
+    case behavior of
+        Overlay -> "Overlay"
+        Modal -> "Modal"
+        NonModal -> "NonModal"
+
+
+someNonsense : Nonsense
+someNonsense = makeNonsense 99
+
+
+title : MyModel -> String
+title model =
+    model.title


### PR DESCRIPTION
This implements #19

When the `UnresolvedReferenceAnnotator` finds a reference that it cannot
resolve, it will now provide a 'Add Import' quick-fix to attempt to
resolve the reference by adding an import statement for a module containing
the unresolved name.

- In the case where a single candidate is found, the import will be created silently.
- If multiple candidates are found, the user will be shown a popup list of modules from which the name can be resolved.
- If there are no candidates, an error hint will be shown.

# Known Shortcomings
- Imports are inserted alphabetically. Which is fine as long as the user just keeps their imports in a single group. But many (most?) people have 3 groups of imports separated by a blank line: core, 3rd-party and project. 
- This has only been tested on projects up to 100 `.elm` files. May need a more efficient lookup mechanism for larger projects.

Accomodating the 3-group style might be something that we want to do before merging this. But I'm unsure how popular this style is in the Elm community.