### PR TITLE
Add code folding support

### DIFF
--- a/src/main/java/org/elmlang/intellijplugin/Elm.bnf
+++ b/src/main/java/org/elmlang/intellijplugin/Elm.bnf
@@ -53,9 +53,7 @@
 // https://github.com/JetBrains/Grammar-Kit
 // https://github.com/JetBrains/Grammar-Kit/blob/master/HOWTO.md
 
-elmFile ::= blank* [module_declaration] blank* imports_list declaration_item*
-
-private declaration_item ::= (declaration|blank)
+elmFile ::= blank* [module_declaration] blank* imports_list (declaration|blank)*
 
 imports_list ::= import_item* { methods = [getFoldingDescriptor getFoldingPlaceholderText]}
 
@@ -65,7 +63,8 @@ private blank ::=
     WHITE_SPACE
     | INDENTATION
     | FRESH_LINE
-    | comment
+    | line_comment
+    | block_comment
 
 module_declaration ::= [ EFFECT | PORT ] MODULE upper_case_path [ WHERE record ] EXPOSING exposed_values { methods = [getModuleName isExposingAll getReferencesStream] }
 
@@ -90,11 +89,9 @@ as_clause ::= AS upper_case_id
 
 exposing_clause ::= EXPOSING exposed_values { methods = [isExposingAll getReferencesStream] }
 
-comment ::=
-    LINE_COMMENT
-    | level_comment
+line_comment ::= LINE_COMMENT_LEX
 
-level_comment ::= START_COMMENT COMMENT_CONTENT* END_COMMENT
+block_comment ::= START_COMMENT (block_comment|COMMENT_CONTENT)* END_COMMENT
 
 private declaration ::=
     value_declaration

--- a/src/main/java/org/elmlang/intellijplugin/Elm.bnf
+++ b/src/main/java/org/elmlang/intellijplugin/Elm.bnf
@@ -51,9 +51,11 @@
 // https://github.com/JetBrains/Grammar-Kit
 // https://github.com/JetBrains/Grammar-Kit/blob/master/HOWTO.md
 
-elmFile ::= blank* [module_declaration] import_item* declaration_item*
+elmFile ::= blank* [module_declaration] blank* imports_list declaration_item*
 
 private declaration_item ::= (declaration|blank)
+
+imports_list ::= import_item*
 
 private import_item ::= (import_clause|blank)
 

--- a/src/main/java/org/elmlang/intellijplugin/Elm.bnf
+++ b/src/main/java/org/elmlang/intellijplugin/Elm.bnf
@@ -30,6 +30,8 @@
         "org.elmlang.intellijplugin.psi.ElmTypeAnnotationBase"
     implements("module_declaration|exposing_clause") =
         "org.elmlang.intellijplugin.psi.ElmExposingBase"
+    implements("imports_list") =
+        "org.elmlang.intellijplugin.psi.ElmFoldable"
 
     psiImplUtilClass="org.elmlang.intellijplugin.psi.impl.ElmPsiImplUtil"
 
@@ -55,7 +57,7 @@ elmFile ::= blank* [module_declaration] blank* imports_list declaration_item*
 
 private declaration_item ::= (declaration|blank)
 
-imports_list ::= import_item*
+imports_list ::= import_item* { methods = [getFoldingDescriptor getFoldingPlaceholderText]}
 
 private import_item ::= (import_clause|blank)
 

--- a/src/main/java/org/elmlang/intellijplugin/Elm.bnf
+++ b/src/main/java/org/elmlang/intellijplugin/Elm.bnf
@@ -32,6 +32,8 @@
         "org.elmlang.intellijplugin.psi.ElmExposingBase"
     implements("imports_list") =
         "org.elmlang.intellijplugin.psi.ElmFoldable"
+    implements("block_comment") =
+        "org.elmlang.intellijplugin.psi.ElmFoldable"
 
     psiImplUtilClass="org.elmlang.intellijplugin.psi.impl.ElmPsiImplUtil"
 
@@ -91,7 +93,10 @@ exposing_clause ::= EXPOSING exposed_values { methods = [isExposingAll getRefere
 
 line_comment ::= LINE_COMMENT_LEX
 
-block_comment ::= START_COMMENT (block_comment|COMMENT_CONTENT)* END_COMMENT
+block_comment ::= START_COMMENT (block_comment|block_comment_text)* END_COMMENT
+    { methods = [getFoldingDescriptor getFoldingPlaceholderText] }
+
+block_comment_text ::= COMMENT_CONTENT+
 
 private declaration ::=
     value_declaration

--- a/src/main/java/org/elmlang/intellijplugin/Elm.bnf
+++ b/src/main/java/org/elmlang/intellijplugin/Elm.bnf
@@ -15,15 +15,17 @@
 
     implements("(upper|lower)_case_id") = "org.elmlang.intellijplugin.psi.ElmNamedElement"
     implements("(inner_)?value_declaration") =
-        "org.elmlang.intellijplugin.psi.ElmValueDeclarationBase"
+        "org.elmlang.intellijplugin.psi.ElmValueDeclarationBase, org.elmlang.intellijplugin.psi.ElmFoldable"
     implements("operator_declaration_left|(list|union|tuple)_pattern") =
         "org.elmlang.intellijplugin.psi.ElmWithPatternList"
     implements("function_declaration_left") =
         "org.elmlang.intellijplugin.psi.ElmWithPatternList, org.elmlang.intellijplugin.psi.ElmWithSingleId"
     implements("if_else|non_empty_tuple|list(_range)?") =
         "org.elmlang.intellijplugin.psi.ElmWithExpressionList"
-    implements("anonymous_function|(case_of_(branch|header))|field|parenthesed_expression") =
+    implements("anonymous_function|(case_of_header)|field|parenthesed_expression") =
         "org.elmlang.intellijplugin.psi.ElmWithExpression"
+    implements("case_of_branch") =
+        "org.elmlang.intellijplugin.psi.ElmWithExpression, org.elmlang.intellijplugin.psi.ElmFoldable"
     implements("(inner_)?type_annotation") =
         "org.elmlang.intellijplugin.psi.ElmTypeAnnotationBase"
     implements("module_declaration|exposing_clause") =
@@ -101,7 +103,8 @@ private declaration ::=
     recoverWhile = declaration_recover
 }
 
-value_declaration ::= value_declaration_left EQ expression SEPARATION_BY_INDENTATION* { methods = [getReferencesStream] }
+value_declaration ::= value_declaration_left EQ expression SEPARATION_BY_INDENTATION*
+    { methods = [getFoldingDescriptor getFoldingPlaceholderText getReferencesStream] }
 
 type_alias_declaration ::=
     TYPE ALIAS upper_case_id (lower_case_id)* EQ type_definition
@@ -223,7 +226,7 @@ external case_of ::=
 case_of_header ::=
     CASE expression OF { methods = [getReferencesStream] }
 case_of_branch ::=
-    pattern ARROW expression { methods = [getReferencesStream] }
+    pattern ARROW expression { methods = [getFoldingDescriptor getFoldingPlaceholderText getReferencesStream] }
 
 one_or_more_separations ::= SEPARATION_BY_INDENTATION+
 
@@ -235,7 +238,8 @@ private inner_declaration ::=
     inner_value_declaration
     | inner_type_annotation
 inner_value_declaration ::=
-    internal_value_declaration_left EQ expression { methods = [getReferencesStream] }
+    internal_value_declaration_left EQ expression
+    { methods = [getFoldingDescriptor getFoldingPlaceholderText getReferencesStream] }
 inner_type_annotation ::=
     lower_case_id COLON type_definition { methods = [getReferencesStream] }
 

--- a/src/main/java/org/elmlang/intellijplugin/Elm.flex
+++ b/src/main/java/org/elmlang/intellijplugin/Elm.flex
@@ -21,9 +21,11 @@ import static org.elmlang.intellijplugin.psi.ElmTypes.*;
 
 %state IN_COMMENT
 
+%x blockComment
+
 CRLF= (\n|\r|\r\n)
 WHITE_SPACE=[\ \t\f]
-LINE_COMMENT=("--")[^\r\n]*
+LINE_COMMENT_LEX=("--")[^\r\n]*
 IDENTIFIER_CHAR=[[:letter:][:digit:]_']
 HEX_CHAR=[[:digit:]A-Fa-f]
 LOWER_CASE_IDENTIFIER=[:lowercase:]{IDENTIFIER_CHAR}*
@@ -41,15 +43,14 @@ RESERVED=("hiding" | "export" | "foreign" | "deriving")
 <IN_COMMENT> {
     "{-" {
         commentLevel++;
-        return COMMENT_CONTENT;
+        return START_COMMENT;
     }
     "-}" {
         commentLevel--;
         if (commentLevel == 0) {
             yybegin(YYINITIAL);
-            return END_COMMENT;
         }
-        return COMMENT_CONTENT;
+        return END_COMMENT;
     }
     [^-{}]+ {
         return COMMENT_CONTENT;
@@ -175,7 +176,7 @@ RESERVED=("hiding" | "export" | "foreign" | "deriving")
     "`" {
         return BACKTICK;
     }
-    {CRLF}*"{-" {
+    "{-" {
         commentLevel = 1;
         yybegin(IN_COMMENT);
         return START_COMMENT;
@@ -204,8 +205,8 @@ RESERVED=("hiding" | "export" | "foreign" | "deriving")
     ({CRLF}+{WHITE_SPACE}+)+ {
         return TokenType.WHITE_SPACE;
     }
-    {CRLF}*{LINE_COMMENT} {
-        return LINE_COMMENT;
+    {CRLF}*{LINE_COMMENT_LEX} {
+        return LINE_COMMENT_LEX;
     }
     {OPERATOR} {
         return OPERATOR;

--- a/src/main/java/org/elmlang/intellijplugin/ElmParserDefinition.java
+++ b/src/main/java/org/elmlang/intellijplugin/ElmParserDefinition.java
@@ -10,7 +10,6 @@ import com.intellij.psi.FileViewProvider;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.TokenType;
-import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.IFileElementType;
 import com.intellij.psi.tree.TokenSet;
 import org.elmlang.intellijplugin.manualParsing.ElmManualPsiElementFactory;
@@ -21,12 +20,8 @@ import org.jetbrains.annotations.NotNull;
 
 public class ElmParserDefinition implements ParserDefinition {
     public static final TokenSet WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE);
-    public static final TokenSet COMMENTS = TokenSet.create(
-            ElmTypes.LINE_COMMENT,
-            ElmTypes.START_COMMENT,
-            ElmTypes.END_COMMENT,
-            ElmTypes.COMMENT_CONTENT
-        );
+    // This is empty because we need to have everything available to the BNF grammar so that we can fold comments.
+    public static final TokenSet COMMENTS = TokenSet.create();
 
     public static final IFileElementType FILE = new IFileElementType(Language.<ElmLanguage>findInstance(ElmLanguage.class));
 

--- a/src/main/java/org/elmlang/intellijplugin/ElmParserDefinition.java
+++ b/src/main/java/org/elmlang/intellijplugin/ElmParserDefinition.java
@@ -21,7 +21,9 @@ import org.jetbrains.annotations.NotNull;
 public class ElmParserDefinition implements ParserDefinition {
     public static final TokenSet WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE);
     // This is empty because we need to have everything available to the BNF grammar so that we can fold comments.
-    public static final TokenSet COMMENTS = TokenSet.create();
+    public static final TokenSet COMMENTS = TokenSet.create(
+            ElmTypes.LINE_COMMENT_LEX
+    );
 
     public static final IFileElementType FILE = new IFileElementType(Language.<ElmLanguage>findInstance(ElmLanguage.class));
 

--- a/src/main/java/org/elmlang/intellijplugin/features/ElmFoldingBuilder.java
+++ b/src/main/java/org/elmlang/intellijplugin/features/ElmFoldingBuilder.java
@@ -1,0 +1,36 @@
+package org.elmlang.intellijplugin.features;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.lang.folding.FoldingBuilderEx;
+import com.intellij.lang.folding.FoldingDescriptor;
+import com.intellij.openapi.editor.Document;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.elmlang.intellijplugin.psi.ElmFoldable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.stream.Collectors;
+
+public class ElmFoldingBuilder extends FoldingBuilderEx {
+
+    @NotNull
+    @Override
+    public FoldingDescriptor[] buildFoldRegions(@NotNull PsiElement root, @NotNull Document document, boolean quick) {
+        return PsiTreeUtil.findChildrenOfType(root, ElmFoldable.class).stream()
+                .map(ElmFoldable::getFoldingDescriptor)
+                .collect(Collectors.toList()).toArray(new FoldingDescriptor[0]);
+    }
+
+    @Nullable
+    @Override
+    public String getPlaceholderText(@NotNull ASTNode node) {
+        return node.getPsi(ElmFoldable.class).getFoldingPlaceholderText();
+    }
+
+    @Override
+    public boolean isCollapsedByDefault(@NotNull ASTNode node) {
+        return false;
+    }
+
+}

--- a/src/main/java/org/elmlang/intellijplugin/psi/ElmCaseOf.java
+++ b/src/main/java/org/elmlang/intellijplugin/psi/ElmCaseOf.java
@@ -2,5 +2,5 @@ package org.elmlang.intellijplugin.psi;
 
 import com.intellij.psi.PsiElement;
 
-public interface ElmCaseOf extends PsiElement {
+public interface ElmCaseOf extends PsiElement, ElmFoldable {
 }

--- a/src/main/java/org/elmlang/intellijplugin/psi/ElmElementFactory.java
+++ b/src/main/java/org/elmlang/intellijplugin/psi/ElmElementFactory.java
@@ -3,6 +3,7 @@ package org.elmlang.intellijplugin.psi;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFileFactory;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elmlang.intellijplugin.ElmFileType;
 import org.elmlang.intellijplugin.utils.ListUtils;
 import org.jetbrains.annotations.Nullable;
@@ -25,20 +26,16 @@ public class ElmElementFactory {
     @Nullable
     public static ElmLowerCaseId createLowerCaseId(Project project, String text) {
         final ElmFile file = createFile(project, String.format("%s=0", text));
-        return Optional.ofNullable(file.getFirstChild())
-                .filter(e -> e instanceof ElmValueDeclaration)
-                .flatMap(e -> Optional.ofNullable(((ElmValueDeclaration)e).getPattern()))
+        return Optional.ofNullable(PsiTreeUtil.findChildOfType(file, ElmValueDeclaration.class))
+                .flatMap(e -> Optional.ofNullable(e.getPattern()))
                 .flatMap(e -> ListUtils.head(e.getLowerCaseIdList()))
                 .orElse(null);
     }
 
     @Nullable
     public static ElmImportClause createImport(Project project, String moduleName) {
-        final ElmFile file = createFile(project, String.format("import %s", moduleName));
-        return Optional.ofNullable(file.getFirstChild())
-                .filter(e -> e instanceof ElmImportClause)
-                .map(e -> (ElmImportClause) e)
-                .orElse(null);
+        ElmFile file = createFile(project, String.format("import %s", moduleName));
+        return PsiTreeUtil.findChildOfType(file, ElmImportClause.class);
     }
 
     @Nullable
@@ -49,11 +46,8 @@ public class ElmElementFactory {
     @Nullable
     public static ElmImportClause createImportExposing(Project project, String moduleName, List<String> exposedNames) {
         String contents = String.join(", ", exposedNames);
-        final ElmFile file = createFile(project, String.format("import %s exposing (%s)", moduleName, contents));
-        return Optional.ofNullable(file.getFirstChild())
-                .filter(e -> e instanceof ElmImportClause)
-                .map(e -> (ElmImportClause) e)
-                .orElse(null);
+        ElmFile file = createFile(project, String.format("import %s exposing (%s)", moduleName, contents));
+        return PsiTreeUtil.findChildOfType(file, ElmImportClause.class);
     }
 
     @Nullable

--- a/src/main/java/org/elmlang/intellijplugin/psi/ElmFile.java
+++ b/src/main/java/org/elmlang/intellijplugin/psi/ElmFile.java
@@ -203,7 +203,7 @@ public class ElmFile extends PsiFileBase implements ElmWithValueDeclarations {
         for (PsiElement elem = this.getFirstChild(); elem != null; elem = elem.getNextSibling()) {
             if (elem instanceof ElmModuleDeclaration) {
                 return Optional.of((ElmModuleDeclaration) elem);
-            } else if (elem instanceof ElmImportClause) {
+            } else if (elem instanceof ElmImportsList) {
                 break;
             }
         }

--- a/src/main/java/org/elmlang/intellijplugin/psi/ElmFoldable.java
+++ b/src/main/java/org/elmlang/intellijplugin/psi/ElmFoldable.java
@@ -1,0 +1,10 @@
+package org.elmlang.intellijplugin.psi;
+
+import com.intellij.lang.folding.FoldingDescriptor;
+import com.intellij.psi.PsiElement;
+
+public interface ElmFoldable extends PsiElement {
+    FoldingDescriptor getFoldingDescriptor();
+
+    String getFoldingPlaceholderText();
+}

--- a/src/main/java/org/elmlang/intellijplugin/psi/impl/ElmCaseOfImpl.java
+++ b/src/main/java/org/elmlang/intellijplugin/psi/impl/ElmCaseOfImpl.java
@@ -1,5 +1,7 @@
 package org.elmlang.intellijplugin.psi.impl;
 
+import com.intellij.lang.folding.FoldingDescriptor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
@@ -17,4 +19,14 @@ public class ElmCaseOfImpl extends ElmPsiElement implements ElmCaseOf {
         }
         else super.accept(visitor);
     }
+
+    public FoldingDescriptor getFoldingDescriptor() {
+        return new FoldingDescriptor(getNode(), getTextRange());
+    }
+
+    public String getFoldingPlaceholderText() {
+        ElmCaseOfHeader header =  PsiTreeUtil.findChildOfType(this, ElmCaseOfHeader.class);
+        return header != null ? header.getText() : "case ... of";
+    }
+
 }

--- a/src/main/java/org/elmlang/intellijplugin/psi/impl/ElmPsiImplUtil.java
+++ b/src/main/java/org/elmlang/intellijplugin/psi/impl/ElmPsiImplUtil.java
@@ -67,6 +67,10 @@ public class ElmPsiImplUtil {
         }
     }
 
+    public static FoldingDescriptor getFoldingDescriptor(ElmBlockComment element) {
+        return new FoldingDescriptor(element.getNode(), element.getTextRange());
+    }
+
     public static FoldingDescriptor getFoldingDescriptor(ElmCaseOfBranch element) {
         return new FoldingDescriptor(element.getNode(), element.getTextRange());
     }
@@ -82,6 +86,11 @@ public class ElmPsiImplUtil {
 
     public static FoldingDescriptor getFoldingDescriptor(ElmValueDeclarationBase element) {
         return new FoldingDescriptor(element.getNode(), element.getTextRange());
+    }
+
+    public static String getFoldingPlaceholderText(ElmBlockComment element) {
+        List<ElmBlockCommentText> texts = element.getBlockCommentTextList();
+        return texts.isEmpty() ? "" : texts.get(0).getText().split("\\n")[0];
     }
 
     public static String getFoldingPlaceholderText(ElmCaseOfBranch element) {

--- a/src/main/java/org/elmlang/intellijplugin/psi/impl/ElmPsiImplUtil.java
+++ b/src/main/java/org/elmlang/intellijplugin/psi/impl/ElmPsiImplUtil.java
@@ -1,6 +1,7 @@
 package org.elmlang.intellijplugin.psi.impl;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.lang.folding.FoldingDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.psi.PsiElement;
@@ -62,6 +63,30 @@ public class ElmPsiImplUtil {
             return node.getPsi();
         } else {
             return null;
+        }
+    }
+
+    public static FoldingDescriptor getFoldingDescriptor(ElmCaseOfBranch element) {
+        return new FoldingDescriptor(element.getNode(), element.getTextRange());
+    }
+
+    public static FoldingDescriptor getFoldingDescriptor(ElmValueDeclarationBase element) {
+        return new FoldingDescriptor(element.getNode(), element.getTextRange());
+    }
+
+    public static String getFoldingPlaceholderText(ElmCaseOfBranch element) {
+        return element.getPattern().getText();
+    }
+
+    public static String getFoldingPlaceholderText(ElmValueDeclarationBase element) {
+        if (element.getFunctionDeclarationLeft() != null) {
+            return element.getFunctionDeclarationLeft().getText();
+        } else if (element.getOperatorDeclarationLeft() != null) {
+            return element.getOperatorDeclarationLeft().getText();
+        } else if (element.getPattern() != null) {
+            return element.getPattern().getText();
+        } else {
+            return "...";
         }
     }
 

--- a/src/main/java/org/elmlang/intellijplugin/psi/impl/ElmPsiImplUtil.java
+++ b/src/main/java/org/elmlang/intellijplugin/psi/impl/ElmPsiImplUtil.java
@@ -4,6 +4,7 @@ import com.intellij.lang.ASTNode;
 import com.intellij.lang.folding.FoldingDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -70,12 +71,25 @@ public class ElmPsiImplUtil {
         return new FoldingDescriptor(element.getNode(), element.getTextRange());
     }
 
+    public static FoldingDescriptor getFoldingDescriptor(ElmImportsList element) {
+        List<ElmImportClause> imports = element.getImportClauseList();
+        if (imports.isEmpty()) { return null; }
+        ElmImportClause first = imports.get(0);
+        ElmImportClause last = imports.get(imports.size() - 1);
+        return new FoldingDescriptor(element.getNode(),
+                new TextRange(first.getTextRange().getStartOffset(), last.getTextRange().getEndOffset()));
+    }
+
     public static FoldingDescriptor getFoldingDescriptor(ElmValueDeclarationBase element) {
         return new FoldingDescriptor(element.getNode(), element.getTextRange());
     }
 
     public static String getFoldingPlaceholderText(ElmCaseOfBranch element) {
         return element.getPattern().getText();
+    }
+
+    public static String getFoldingPlaceholderText(ElmImportsList element) {
+        return "imports (" + element.getImportClauseList().size() + ")";
     }
 
     public static String getFoldingPlaceholderText(ElmValueDeclarationBase element) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -110,6 +110,9 @@
         <completion.contributor
                 language="Elm"
                 implementationClass="org.elmlang.intellijplugin.features.completion.ElmCompletionContributor"/>
+        <lang.foldingBuilder
+                language="Elm"
+                implementationClass="org.elmlang.intellijplugin.features.ElmFoldingBuilder"/>
         <spellchecker.support
                 language="Elm"
                 implementationClass="com.intellij.spellchecker.tokenizer.SpellcheckingStrategy"/>


### PR DESCRIPTION
Fixes durkiewicz/elm-plugin#29. So far support is in place for folding
value declarations, case expressions, and case branches.

It doesn't currently fold the list of import statements, or comments, as I'd like to discuss how best to approach that. It seems like the preferred approach would be to alter the AST so that there is a parent node which represents the list of imports, ditto for block comments. So for imports making a change like this (to `Elm.bnf`)

```
elmFile ::= blank* [module_declaration] imports* declaration_item*

imports ::= import_item*

private import_item ::= (import_clause|blank)
```

but I'm not currently sure how this would impact the import intention action.