### PR TITLE
Let in indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Formatting is currently not a feature of the plugin, but `elm-format` can be use
 0. Setup your development environment according to [this instruction](http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/setting_up_environment.html).
 0. Clone this repository.
 0. Open it as a Plugin Project in IntelliJ IDEA (either Community or Ultimate version).
-0. Make sure you have Grammar-Kit and PsiViewer plugins installed.
+0. Make sure you have `Grammar-Kit` and `PsiViewer` plugins installed.
 0. Delete the content of `gen` directory if you have previously generated parser code from another version of the BNF file.
-0. Open `src/main/java/org/elmlang/intellijplugin/Elm.bnf` file and generate the parser code (*)
+0. Open `src/main/java/org/elmlang/intellijplugin/Elm.bnf` file and generate the parser code - twice, if needed (*)
 0. Open `src/main/java/org/elmlang/intellijplugin/Elm.flex` file and generate lexer code (*)
 0. The plugin should be ready to run now.
 

--- a/src/main/java/org/elmlang/intellijplugin/manualParsing/IndentationHelper.java
+++ b/src/main/java/org/elmlang/intellijplugin/manualParsing/IndentationHelper.java
@@ -7,7 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class IndentationHelper {
-    private static final Pattern indentationPattern = Pattern.compile(".*[\r\n]([ \t][^\r\n]+)$", Pattern.DOTALL);
+    private static final Pattern indentationPattern = Pattern.compile(".*[\r\n]([^\r\n]+)$", Pattern.DOTALL);
 
     public static int getIndentationOfPreviousToken(PsiBuilder builder) {
         // getTokenType has some side effects. Do not remove the call.


### PR DESCRIPTION
Fixes https://github.com/durkiewicz/elm-plugin/issues/52

Note: this doesn't fix the indentation issue of pressing enter after the `let`, i.e. it will still go to the beginning of the line