### PR TITLE
Fix development setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.idea
+.idea/*
+!.idea/modules.xml
 /out
 /gen
 /src/main/java/org/elmlang/intellijplugin/ElmLexer.java

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/elm-plugin.iml" filepath="$PROJECT_DIR$/elm-plugin.iml" />
+    </modules>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ Formatting is currently not a feature of the plugin, but `elm-format` can be use
 0. Open it as a Plugin Project in IntelliJ IDEA (either Community or Ultimate version).
 0. Make sure you have `Grammar-Kit` and `PsiViewer` plugins installed.
 0. Delete the content of `gen` directory if you have previously generated parser code from another version of the BNF file.
-0. Open `src/main/java/org/elmlang/intellijplugin/Elm.bnf` file and generate the parser code - twice, if needed (*)
 0. Open `src/main/java/org/elmlang/intellijplugin/Elm.flex` file and generate lexer code (*)
-0. The plugin should be ready to run now.
+0. Open `src/main/java/org/elmlang/intellijplugin/Elm.bnf` file and generate the parser code - twice, if needed (*)
+0. Open `File -> Project Structure` under `Project` set the `Projekt SDK` to the (in Step 1) configured `IntelliJ Platform Plugin SDK`, the `Project language level` at least to `8` and the `Project compiler output` to `out`
+0. Create a `Plugin`-Run Configuration
 
 (*) either from a context menu or by keyboard shortcut ⇧⌘G
 


### PR DESCRIPTION
The modules.xml file was ignored in git.

This made IntelliJ import the plugin as a Java project and
the Source/Resources/Test-Folders where not recognized and
led people to do unnecessary steps e.g. in #46 

With the modules.xml included, IntelliJ (tested with 2017.1.4) now correctly imports the
project and makes it easier to start developing.

Apart from that I've expanded the steps to get this plugin to build.